### PR TITLE
Add required ppa

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN add-apt-repository -y ppa:myriadrf/drivers && \
 #RUN apt-get -y install gqrx-sdr
 RUN apt-get -y install gqrx-sdr soapysdr-tools soapysdr-module-lms7
 
+
 # Build deps
 # TODO: Validate
 RUN apt-get install -y cmake g++ libpython-dev python-numpy swig \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN \
 # PPAs
 RUN add-apt-repository -y ppa:myriadrf/drivers && \
     add-apt-repository -y ppa:myriadrf/gnuradio && \
+    add-apt-repository -y ppa:bladerf/bladerf && \
     add-apt-repository -y ppa:gqrx/gqrx-sdr && \
     apt-get -y update
 
@@ -17,7 +18,6 @@ RUN add-apt-repository -y ppa:myriadrf/drivers && \
 # TODO: Install both from source so we can be more portable.
 #RUN apt-get -y install gqrx-sdr
 RUN apt-get -y install gqrx-sdr soapysdr-tools soapysdr-module-lms7
-
 
 # Build deps
 # TODO: Validate


### PR DESCRIPTION
The latest Gqrx package requires the PPA ppa:bladerf/bladerf to install it, according to the following URL:

- https://gqrx.dk/download/install-ubuntu

If it is not added, the build process will fail because some required packages are missing.